### PR TITLE
Bug Fix - Team Info page always shows "Sign In" button

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -13,8 +13,6 @@ const inter = Inter({ subsets: ["latin"] });
 
 export default function Home(props) {
   const { data: session } = useSession();
-  console.log(session);
-  console.log(props);
   
   return (
     <Layout>
@@ -22,7 +20,7 @@ export default function Home(props) {
       {session && !props.user && (
         <strong>Please ask an admin to add you as user!</strong>
       )}
-      < LandingPage user={props.user}></ LandingPage>
+      <LandingPage user={props.user}></ LandingPage>
     </Layout>
   );
 }

--- a/pages/navigation/Navigation.js
+++ b/pages/navigation/Navigation.js
@@ -46,9 +46,20 @@ function Navigation({ user } = props) {
           </button>
         </div>
         <div>
-          {user && role != "invalid" && (
-            <div className="collapse navbar-collapse" id="navbarNav">
-              <ul className="navbar-nav">
+          <div className="collapse navbar-collapse" id="navbarNav">
+            <ul className="navbar-nav">
+              <li className="nav-item p-4">
+                <Link href="/teaminfo" legacyBehavior>
+                  <a
+                    className={`nav-link custom-link ${
+                      router.pathname === "/teaminfo" ? "active" : ""
+                    }`}
+                  >
+                    Team Info
+                  </a>
+                </Link>
+              </li>
+              {user && role != "invalid" && (
                 <li className="nav-item p-4">
                   <Link href="/beneficiary" legacyBehavior>
                     <a
@@ -60,6 +71,8 @@ function Navigation({ user } = props) {
                     </a>
                   </Link>
                 </li>
+              )}
+              {user && role != "invalid" && (
                 <li className="nav-item p-4">
                   <Link href="/reports" legacyBehavior>
                     <a
@@ -71,54 +84,37 @@ function Navigation({ user } = props) {
                     </a>
                   </Link>
                 </li>
-                {/* don't display if technician */}
-                {(role === "admin" || role === "manager") && (
-                  <li className="nav-item p-4">
-                    <Link href="/users" legacyBehavior>
-                      <a
-                        className={`nav-link custom-link ${
-                          router.pathname === "/users" ? "active" : ""
-                        }`}
-                      >
-                        Users
-                      </a>
-                    </Link>
-                  </li>
-                )}
-                {/* display only if admin */}
-                {role === "admin" && (
-                  <li className="nav-item p-4">
-                    <Link href="/requiredfields" legacyBehavior>
-                      <a
-                        className={`nav-link custom-link ${
-                          router.pathname === "/requiredfields" ? "active" : ""
-                        }`}
-                      >
-                        Configuration
-                      </a>
-                    </Link>
-                  </li>
-                )}
-              </ul>
-            </div>
-          )}
-          {!user && (
-            <div className="right auto-margin column-center">
-              <ul className="navbar-nav">
+              )}
+              {/* don't display if technician */}
+              {user && role != "invalid" && (role === "admin" || role === "manager") && (
                 <li className="nav-item p-4">
-                  <Link href="/teaminfo" legacyBehavior>
+                  <Link href="/users" legacyBehavior>
                     <a
                       className={`nav-link custom-link ${
-                        router.pathname === "/teaminfo" ? "active" : ""
+                        router.pathname === "/users" ? "active" : ""
                       }`}
                     >
-                      Team Info
+                      Users
                     </a>
                   </Link>
                 </li>
-              </ul>
-            </div>
-          )}
+              )}
+              {/* display only if admin */}
+              {user && role != "invalid" && role === "admin" && (
+                <li className="nav-item p-4">
+                  <Link href="/requiredfields" legacyBehavior>
+                    <a
+                      className={`nav-link custom-link ${
+                        router.pathname === "/requiredfields" ? "active" : ""
+                      }`}
+                    >
+                      Configuration
+                    </a>
+                  </Link>
+                </li>
+              )}
+            </ul>
+          </div>
         </div>
         {user && (
           <div className="left-auto-margin column">

--- a/pages/teaminfo.js
+++ b/pages/teaminfo.js
@@ -5,11 +5,30 @@ import amber from 'public/images/amber.webp';
 import chris from 'public/images/chris.webp';
 import nasa from 'public/images/nasa.webp';
 import Layout from './components/layout';
+import { getSession } from "next-auth/react";
+import { readUser } from "./api/user";
 
-export default function TeamInfo() {
+export async function getServerSideProps(ctx) {
+  const session = await getSession(ctx);
+  if (session == null) {
+    return {
+      props: {
+        user: null
+      }
+    };
+  }
+  const user = await readUser(session.user.email);
+  return {
+    props: {
+      user: user,
+    },
+  };
+}
+
+export default function TeamInfo(props) {
   return (
     <Layout>
-      <Navigation />
+      <Navigation user={props.user}/>
       <div className="container">
         <div className="team-info">
           <h1>Project Description</h1>


### PR DESCRIPTION
Fixed a bug with displaying the team info page. We now display it all the time in the nav bar, and pass the user object along correctly.

Here is what the site looks like with the changes:

Not Signed In
<img width="1761" alt="Screenshot 2024-03-12 at 8 17 55 AM" src="https://github.com/ajbieber/vision-aid-partners/assets/17572432/6d5938b4-dcd0-4b7f-a0d7-927d74388b9f">

Signed In, Team Info Selected
<img width="888" alt="Screenshot 2024-03-12 at 8 18 55 AM" src="https://github.com/ajbieber/vision-aid-partners/assets/17572432/c4fe1f57-a7af-49f8-bb3c-516f6288df8a">

Signed In, Team Info NOT Selected
<img width="887" alt="Screenshot 2024-03-12 at 8 19 17 AM" src="https://github.com/ajbieber/vision-aid-partners/assets/17572432/080fe3e3-55c8-49a2-b3c5-6fb2cd165ca4">


Closes #32 
